### PR TITLE
Fixes issue #8, response code -1

### DIFF
--- a/src/main/java/com/integralblue/httpresponsecache/compat/libcore/net/http/ResponseHeaders.java
+++ b/src/main/java/com/integralblue/httpresponsecache/compat/libcore/net/http/ResponseHeaders.java
@@ -479,6 +479,9 @@ public final class ResponseHeaders {
     public ResponseHeaders combine(ResponseHeaders network) {
         RawHeaders result = new RawHeaders();
 
+        // Need to replicate the status line to the result object
+        result.setStatusLine(network.headers.getStatusLine());
+
         for (int i = 0; i < headers.length(); i++) {
             String fieldName = headers.getFieldName(i);
             String value = headers.getValue(i);


### PR DESCRIPTION
This is due to a new result object being formed and the status line not being applied to that result object in `ResponseHeaders#combine(ResponseHeaders)`
