### PR TITLE
ISSUE-3: SimpleDateFormat can be extremely slow to parse

### DIFF
--- a/src/main/java/com/integralblue/httpresponsecache/compat/libcore/net/http/HttpDate.java
+++ b/src/main/java/com/integralblue/httpresponsecache/compat/libcore/net/http/HttpDate.java
@@ -22,24 +22,20 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.Locale;
 import java.util.TimeZone;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
 
 /**
  * Best-effort parser for HTTP dates.
  */
 public final class HttpDate {
+    private static final int RFC1123_PARSER_POOL_SIZE = 10;
 
     /**
      * Most websites serve cookies in the blessed format. Eagerly create the parser to ensure such
      * cookies are on the fast path.
      */
-    private static final ThreadLocal<DateFormat> STANDARD_DATE_FORMAT
-            = new ThreadLocal<DateFormat>() {
-        @Override protected DateFormat initialValue() {
-            DateFormat rfc1123 = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
-            rfc1123.setTimeZone(TimeZone.getTimeZone("UTC"));
-            return rfc1123;
-        }
-    };
+    static final DateFormatPoolRfc1123 sParserPoolRfc1123 = new DateFormatPoolRfc1123(RFC1123_PARSER_POOL_SIZE);
 
     /**
      * If we fail to parse a date in a non-standard format, try each of these formats in sequence.
@@ -69,9 +65,14 @@ public final class HttpDate {
      * parsed.
      */
     public static Date parse(String value) {
+        DateFormat parser = null;
+
         try {
-            return STANDARD_DATE_FORMAT.get().parse(value);
+            parser = sParserPoolRfc1123.take();
+            return parser.parse(value);
         } catch (ParseException ignore) {
+        } finally {
+            sParserPoolRfc1123.put(parser);
         }
         for (String formatString : BROWSER_COMPATIBLE_DATE_FORMATS) {
             try {
@@ -86,6 +87,60 @@ public final class HttpDate {
      * Returns the string for {@code value}.
      */
     public static String format(Date value) {
-        return STANDARD_DATE_FORMAT.get().format(value);
+        DateFormat formatter = sParserPoolRfc1123.take();
+        String formattedString = formatter.format(value);
+        sParserPoolRfc1123.put(formatter);
+        return formattedString;
+    }
+
+    /** Class that creates a pool of RFC1123 DataFormat objects and allows taking, and returning those objects. */
+    public static final class DateFormatPoolRfc1123 {
+
+        private final BlockingQueue<DateFormat> mObjects;
+
+        public DateFormatPoolRfc1123(int capacity) {
+            mObjects = new ArrayBlockingQueue<DateFormat>(capacity, false);
+
+            // Create a thread to populate the pool of date parsers.
+            new Thread(new Runnable() {
+                public void run() {
+                    TimeZone timeZone = TimeZone.getTimeZone("UTC");
+
+                    for (int i = 0; i < RFC1123_PARSER_POOL_SIZE; i++) {
+                        SimpleDateFormat parserRfc1123 = new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
+                        parserRfc1123.setTimeZone(timeZone);
+                        sParserPoolRfc1123.put(parserRfc1123);
+                    }
+                }
+            }).start();
+        }
+
+        /**
+         * Take a DateFormat object from the queue.
+         * This will block until a DateFormat object is available.
+         * When done using it be sure to call {@code #put(DateFormat)}}.
+         */
+        public DateFormat take() {
+            try {
+                return mObjects.take();
+            } catch (InterruptedException e) {
+                // This will never be interrupted
+                return null;
+            }
+        }
+
+        /**
+         * Adds an object back onto the queue.
+         * This will block if the queue is already full.
+         */
+        public void put(DateFormat dateFormat) {
+            try {
+                if (dateFormat != null) {
+                    mObjects.put(dateFormat);
+                }
+            } catch (InterruptedException e) {
+                // This will never be interrupted
+            }
+        }
     }
 }


### PR DESCRIPTION
This ticket description is actually somewhat off as far as what the real issue is here.
I used the Android performance analysis tool to discover the real issue is these two lines:

new SimpleDateFormat("EEE, dd MMM yyyy HH:mm:ss zzz", Locale.US);
TimeZone.getTimeZone("UTC")

The root of the issue is that DateFormat is not thread safe, and is very slow to create.
I used the performance analysis tool to try a few approaches to solve the
issue and measure which was most performant. First I tried a simple synchronized access
to a single class wide copy of this variable. For an average test case of about 10 concurrent
downloads this increased the performance to ~5.4 times faster then the baseline. There was now
however a good amount of delay introduced by waiting for the synchronization. So an alternative
approach was tried where a pool of SimpleDateFormat's is created which can be used and recycled
back into the pool. With this approach the performance is now ~10.4 times faster. When I was
analyzing the performance this was by far the single most time consuming task, the entire
library is much faster as a result of this patch.
