### PR TITLE
Overrides set values for Keep-Alive headers

### DIFF
--- a/src/main/java/com/integralblue/httpresponsecache/compat/libcore/net/http/HttpEngine.java
+++ b/src/main/java/com/integralblue/httpresponsecache/compat/libcore/net/http/HttpEngine.java
@@ -692,7 +692,7 @@ public class HttpEngine {
             requestHeaders.setHost(getOriginAddress(policy.getURL()));
         }
 
-        if (httpMinorVersion > 0 && requestHeaders.getConnection() == null) {
+        if (httpMinorVersion > 0 && requestHeaders.getConnection() == null && "false".equals(System.getProperty("http.keepAlive"))) {
             requestHeaders.setConnection("Keep-Alive");
         }
 


### PR DESCRIPTION
Line 696 in file HttpEnglne,java seems to override the system set default values for behavior involving Keep-Alive headers.  This is not always a problem, but the determination should probably be left up to the user.  This can be particularly troubling for Android users interacting with certain servers using the Keep-Alive mechanism.

Example: 
set System.setProperty("http.keepAlive","false");

The intent here is to prevent the http Keep-alive mechanism from being used, specifically for reasons stated above.

But line 695 in HttpEngine.java : 
if (httpMinorVersion > 0 && requestHeaders.getConnection() == null) {
          requestHeaders.setConnection("Keep-Alive");
        }

forces keep-Alive headers to be sent  on a request(assuming use of http 1.1), regardless of the set system property.

In my specific instance this may be more indicative of a problem with the server or request headers in general, but adjusting the above line to avoid using the Keep-Alive mechanism (as I intend) fixed my problem.

The fix i would propose would be to add an extra condition to the above if statement which also checks to make sure that the system property "http.keepAlive" is not set to false before setting that header on an outgoing request.
